### PR TITLE
Update aria-selected for unselected tabs so that VoiceOver announces correctly.

### DIFF
--- a/d2l-tab.html
+++ b/d2l-tab.html
@@ -82,7 +82,7 @@ Polymer-based web components for tab
 				cursor: pointer;
 			}
 
-			:host([aria-selected]:hover) {
+			:host([aria-selected="true"]:hover) {
 				color: inherit;
 				cursor: default;
 			}
@@ -93,12 +93,12 @@ Polymer-based web components for tab
 				box-shadow: none;
 			}
 
-			:host([aria-selected]:focus) .d2l-tab-selected-indicator {
+			:host([aria-selected="true"]:focus) .d2l-tab-selected-indicator {
 				border-top-color: var(--d2l-color-celestine);
 				box-shadow: 0 0 0 3px rgba(0, 111, 191, 0.3);
 			}
 
-			:host([aria-selected]) .d2l-tab-selected-indicator {
+			:host([aria-selected="true"]) .d2l-tab-selected-indicator {
 				display: block;
 			}
 
@@ -112,6 +112,7 @@ Polymer-based web components for tab
 			is: 'd2l-tab',
 
 			hostAttributes: {
+				'aria-selected': 'false',
 				'role': 'tab',
 				'tabindex': '-1'
 			},
@@ -178,7 +179,7 @@ Polymer-based web components for tab
 						'd2l-tab-selected', { bubbles: true, composed: true }
 					));
 				} else {
-					this.removeAttribute('aria-selected');
+					this.setAttribute('aria-selected', 'false');
 				}
 			},
 

--- a/d2l-tab.html
+++ b/d2l-tab.html
@@ -179,6 +179,7 @@ Polymer-based web components for tab
 						'd2l-tab-selected', { bubbles: true, composed: true }
 					));
 				} else {
+					// Note: this must be specified in order for VoiceOver to correctly announce unselected tabs.
 					this.setAttribute('aria-selected', 'false');
 				}
 			},

--- a/d2l-tabs.html
+++ b/d2l-tabs.html
@@ -413,7 +413,7 @@ Polymer-based web components for tabs
 			},
 
 			_focusSelected: function() {
-				var selectedTab = Polymer.dom(this.root).querySelector('d2l-tab[aria-selected]');
+				var selectedTab = Polymer.dom(this.root).querySelector('d2l-tab[aria-selected="true"]');
 				if (selectedTab) {
 					this._updateScrollPosition(selectedTab).then(function() {
 						fastdom.mutate(function() {

--- a/test/tabs.html
+++ b/test/tabs.html
@@ -113,7 +113,7 @@
 								expect(tabs[i].getAttribute('aria-selected')).to.equal('true');
 								expect(tabList.querySelector('#' + tabs[i].getAttribute('aria-controls')).hasAttribute('selected')).to.equal(true);
 							} else {
-								expect(tabs[i].getAttribute('aria-selected')).to.equal(null);
+								expect(tabs[i].getAttribute('aria-selected')).to.equal('false');
 								expect(tabList.querySelector('#' + tabs[i].getAttribute('aria-controls')).hasAttribute('selected')).to.equal(false);
 							}
 						}


### PR DESCRIPTION
If the `aria-selected` attribute is omitted, VoiceOver will announce the tab as selected.  In order for the tab state to be properly announced for unselected tabs, `aria-selected="false"` must be specified.