### PR TITLE
Update tabs so that users will activate the tab manually by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) polyfill loa
 ```
 
 * `max-to-show` (optional): used on `d2l-tabs` to limit set the initial max-width of the tab list (excluding `ext` slot).
-* `no-auto-select` (optional): used on `d2l-tabs` to configure whether tabs are activated upon receiving focus.  Note: [Aria Tab Guidelines](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel) suggest auto select being preferred unless the user will experience latency.
+* `auto-select` (optional): used on `d2l-tabs` to configure whether tabs are activated upon receiving focus.  Note: [Aria Tab Guidelines](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel) suggest auto select being preferred unless the user will experience latency, however auto-focus may be confusing for screen-reader users navigating the page with virtual cursor.
 * `no-padding` (optional): used on `d2l-tab-panel` to opt out of default padding/whitespace for the panel.
 
 Alternatively, `d2l-tab` and `d2l-tab-panel` can be specified with `dom-repeat`.

--- a/d2l-tabs.html
+++ b/d2l-tabs.html
@@ -221,9 +221,9 @@ Polymer-based web components for tabs
 				},
 
 				/**
-				 * Indicates whether tabs are automatically activated on focus.
+				 * Indicates that tabs are automatically activated on focus.
 				 */
-				noAutoSelect: {
+				autoSelect: {
 					type: Boolean
 				},
 
@@ -689,7 +689,7 @@ Polymer-based web components for tabs
 				if (e.target.tagName !== 'D2L-TAB') {
 					return;
 				}
-				if (!this.noAutoSelect && !e.target.selected) {
+				if (this.autoSelect && !e.target.selected) {
 					e.target.selected = true;
 				}
 			},

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,21 +39,21 @@
 					<d2l-tabs>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-						<d2l-tab-panel text="Earth Sciences">Tab content for Earth Sciences</d2l-tab-panel>
+						<d2l-tab-panel text="Earth & Planetary Sciences">Tab content for Earth & Planetary Sciences</d2l-tab-panel>
 						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
 						<d2l-tab-panel text="Math">Tab content for Math</d2l-tab-panel>
 					</d2l-tabs>
 				</template>
 			</demo-snippet>
 
-			<h3>Tabs (no-auto-select)</h3>
+			<h3>Tabs (auto-select)</h3>
 
 			<demo-snippet>
 				<template>
-					<d2l-tabs no-auto-select>
+					<d2l-tabs auto-select>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-						<d2l-tab-panel text="Earth & Planetary Sciences">Tab content for Earth & Planetary Sciences</d2l-tab-panel>
+						<d2l-tab-panel text="Earth Sciences">Tab content for Earth Sciences</d2l-tab-panel>
 						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
 						<d2l-tab-panel text="Math">Tab content for Math</d2l-tab-panel>
 					</d2l-tabs>
@@ -64,7 +64,7 @@
 
 			<demo-snippet>
 				<template>
-					<d2l-tabs no-auto-select>
+					<d2l-tabs>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 						<d2l-tab-panel text="Earth Sciences">Tab content for Earth Sciences</d2l-tab-panel>
@@ -79,7 +79,7 @@
 
 			<demo-snippet>
 				<template>
-					<d2l-tabs no-auto-select>
+					<d2l-tabs>
 						<d2l-tab-panel text="S18">Tab content for S18</d2l-tab-panel>
 						<d2l-tab-panel text="W18">Tab content for W18</d2l-tab-panel>
 						<d2l-tab-panel text="F17">Tab content for F17</d2l-tab-panel>

--- a/test/tabs.html
+++ b/test/tabs.html
@@ -151,8 +151,9 @@
 						expectSelected(tabs[0], tabs);
 					});
 
-					it('selects tab if focused', function(done) {
+					it('selects tab if auto-select is specific and tab is focused', function(done) {
 						var tabs = tabList._getTabsContainer().querySelectorAll('d2l-tab');
+						tabList.autoSelect = true;
 						expectSelectedEvent(tabs[2], tabs, done);
 						MockInteractions.focus(tabs[2]);
 					});
@@ -164,9 +165,8 @@
 						tabPanels[2].selected = true;
 					});
 
-					it('does not select tab when focused if no-auto-select is specified', function(done) {
+					it('does not select tab when focused if auto-select is not specified', function(done) {
 						var tabs = tabList._getTabsContainer().querySelectorAll('d2l-tab');
-						tabList.noAutoSelect = true;
 						MockInteractions.focus(tabs[2]);
 						setTimeout(function() {
 							expectSelected(tabs[0], tabs);


### PR DESCRIPTION
Tabs that "auto-focus" can lead to a confusing experience if using screen-reader and navigating the page with the virtual cursor.  For this reason, set default behavior so users manually select the tab after applying focus.