### PR TITLE
Update to use resize-observer instead of window resize event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "d2l-icons": "^5.0.0",
     "d2l-localize-behavior": "^1.0.0",
     "d2l-polymer-behaviors": "^1.6.2",
+    "d2l-resize-observer-polyfill-import": "https://github.com/Brightspace/resize-observer-polyfill-import.git#^1.5.1",
     "d2l-typography": "^6.1.2",
     "polymer": "1.9 - 2"
   },

--- a/d2l-tabs.html
+++ b/d2l-tabs.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom-focus.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-arrowkeys-behavior.html">
+<link rel="import" href="../d2l-resize-observer-polyfill-import/resize-observer.html">
 <link rel="import" href="d2l-tab.html">
 <link rel="import" href="d2l-tab-panel.html">
 <link rel="import" href="localize-behavior.html">
@@ -308,7 +309,9 @@ Polymer-based web components for tabs
 					Polymer.dom(this.root).querySelector('.d2l-tabs-scroll-next-container button').addEventListener('click', this._handleScrollNext);
 					Polymer.dom(this.root).querySelector('.d2l-tabs-scroll-previous-container button').addEventListener('click', this._handleScrollPrevious);
 
-					window.addEventListener('resize', this._handleResize);
+					this._resizeObserver = new ResizeObserver(this._handleResize);
+					this._resizeObserver.observe(tabsList);
+
 				}.bind(this));
 			},
 
@@ -325,7 +328,7 @@ Polymer-based web components for tabs
 					Polymer.dom(this).unobserveNodes(this._slotObserver);
 				}
 
-				window.removeEventListener('resize', this._handleResize);
+				if (this._resizeObserver) this._resizeObserver.unobserve(tabsList);
 			},
 
 			_calculateScrollPosition: function(selectedTab, measures) {


### PR DESCRIPTION
This change is being made to better enable the use of tabs in dropdowns.  When the dropdown (containing the tabs) is opened, the tabs measurement logic needs to be retriggered since when it was originally run it would not have been visible in the DOM, resulting in 0-value measurements.

This change has the added benefit of improving tabs performance.  Previously with the window resize event, the tabs measurement logic would be run even for tabs that are hidden in closed dropdowns.  By using the resize-observer, this unnecessary work is avoided.