### PR TITLE
Update style of focused tabs for wcag 2.1. [increment patch]

### DIFF
--- a/d2l-tab.js
+++ b/d2l-tab.js
@@ -69,6 +69,15 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-tab">
 				margin-right: 0;
 			}
 
+			:host(:focus) {
+				color: var(--d2l-color-celestine);
+				text-decoration: underline;
+			}
+
+			:host([aria-selected="true"]:focus) {
+				text-decoration: none;
+			}
+
 			:host(:hover) {
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
@@ -79,20 +88,13 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-tab">
 				cursor: default;
 			}
 
-			:host(:focus) .d2l-tab-selected-indicator {
+			:host([aria-selected="true"]) .d2l-tab-selected-indicator {
 				display: block;
-				border-top-color: rgba(0, 111, 191, 0.4);
-				box-shadow: none;
-				transition: border-top-color 0.2s, box-shadow 0.2s;
 			}
 
 			:host([aria-selected="true"]:focus) .d2l-tab-selected-indicator {
 				border-top-color: var(--d2l-color-celestine);
 				box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px var(--d2l-color-celestine);
-			}
-
-			:host([aria-selected="true"]) .d2l-tab-selected-indicator {
-				display: block;
 			}
 
 		</style>


### PR DESCRIPTION
This updates the focus style of tabs.

biology selected & focused; chemistry hovered
![tabs2](https://user-images.githubusercontent.com/9042472/59283480-a2450400-8c38-11e9-9b5e-a68976156b59.png)

biology selected; earth focused
![tabs3](https://user-images.githubusercontent.com/9042472/59283533-be48a580-8c38-11e9-8b95-3ff0ac0f8574.png)
