### PR TITLE
Add d2l-dropdown-tabs demos

### DIFF
--- a/demo/d2l-demo-dropdown-tabs.js
+++ b/demo/d2l-demo-dropdown-tabs.js
@@ -1,0 +1,102 @@
+import '@polymer/polymer/polymer-legacy.js';
+import '../../@brightspace-ui/core/components/menu/menu.js';
+import '../../@brightspace-ui/core/components/menu/menu-item.js';
+import '../../@brightspace-ui/core/components/dropdown/dropdown.js';
+import '../../@brightspace-ui/core/components/dropdown/dropdown-tabs.js';
+import '../d2l-tabs.js';
+import '../d2l-tab-panel.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+const $_documentContainer = document.createElement('template');
+
+$_documentContainer.innerHTML = `<dom-module id="d2l-demo-dropdown-tabs">
+	<template strip-whitespace="">
+		<d2l-dropdown>
+			<button class="d2l-dropdown-opener">Open it!</button>
+			<d2l-dropdown-tabs min-width="175" max-width="300">
+				<d2l-tabs>
+					<d2l-tab-panel text="first">first content</d2l-tab-panel>
+					<d2l-tab-panel text="second">
+						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+					</d2l-tab-panel>
+					<d2l-tab-panel text="third">
+						<d2l-menu label="Astronomy">
+							<d2l-menu-item text="Introduction" id="first-item"></d2l-menu-item>
+							<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+							<d2l-menu-item text="The Solar System">
+								<d2l-menu>
+									<d2l-menu-item text="Formation"></d2l-menu-item>
+									<d2l-menu-item text="Modern Solar System"></d2l-menu-item>
+									<d2l-menu-item text="Future Solar System"></d2l-menu-item>
+									<d2l-menu-item text="The Planets">
+										<d2l-menu>
+											<d2l-menu-item text="Mercury"></d2l-menu-item>
+											<d2l-menu-item text="Venus"></d2l-menu-item>
+											<d2l-menu-item text="Earth"></d2l-menu-item>
+											<d2l-menu-item text="Mars"></d2l-menu-item>
+											<d2l-menu-item text="Jupiter"></d2l-menu-item>
+											<d2l-menu-item text="Saturn"></d2l-menu-item>
+											<d2l-menu-item text="Uranus"></d2l-menu-item>
+											<d2l-menu-item text="Neptune"></d2l-menu-item>
+											<d2l-menu-item text="Dwarf Planets"></d2l-menu-item>
+										</d2l-menu>
+									</d2l-menu-item>
+									<d2l-menu-item text="The Sun"></d2l-menu-item>
+									<d2l-menu-item text="Solar &amp; Lunar Eclipses"></d2l-menu-item>
+									<d2l-menu-item text="Meteors &amp; Meteorites"></d2l-menu-item>
+									<d2l-menu-item text="Asteroids"></d2l-menu-item>
+									<d2l-menu-item text="Comets"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-menu-item>
+							<d2l-menu-item text="Stars &amp; Galaxies">
+								<d2l-menu>
+									<d2l-menu-item text="What is a Star?"></d2l-menu-item>
+									<d2l-menu-item text="Lifecycle of a Star"></d2l-menu-item>
+									<d2l-menu-item text="Binaries &amp; Multiples"></d2l-menu-item>
+									<d2l-menu-item text="Star Clusters"></d2l-menu-item>
+									<d2l-menu-item text="Star Death">
+										<d2l-menu>
+											<d2l-menu-item text="Supernovae"></d2l-menu-item>
+											<d2l-menu-item text="Black Holes"></d2l-menu-item>
+										</d2l-menu>
+									</d2l-menu-item>
+									<d2l-menu-item text="Star Clusters"></d2l-menu-item>
+									<d2l-menu-item text="Galaxies">
+										<d2l-menu>
+											<d2l-menu-item text="Classification"></d2l-menu-item>
+											<d2l-menu-item text="Birth &amp; Evolution"></d2l-menu-item>
+											<d2l-menu-item text="Spiral"></d2l-menu-item>
+											<d2l-menu-item text="Elliptical"></d2l-menu-item>
+											<d2l-menu-item text="Lenticular"></d2l-menu-item>
+											<d2l-menu-item text="Irregular"></d2l-menu-item>
+											<d2l-menu-item text="Active &amp; Radio"></d2l-menu-item>
+											<d2l-menu-item text="Quasars"></d2l-menu-item>
+											<d2l-menu-item text="Galaxy Clusters"></d2l-menu-item>
+										</d2l-menu>
+									</d2l-menu-item>
+								</d2l-menu>
+							</d2l-menu-item>
+							<d2l-menu-item text="The Night Sky">
+								<d2l-menu>
+									<d2l-menu-item text="Constellations"></d2l-menu-item>
+									<d2l-menu-item text="Mapping the Heavens"></d2l-menu-item>
+									<d2l-menu-item text="Reading Star Maps"></d2l-menu-item>
+									<d2l-menu-item text="Telescopes"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-menu-item>
+							<d2l-menu-item text="The Universe" id="last-item"></d2l-menu-item>
+						</d2l-menu>
+					</d2l-tab-panel>
+					<d2l-tab-panel text="fourth">fourth content</d2l-tab-panel>
+					<d2l-tab-panel text="fith">fith content</d2l-tab-panel>
+					<d2l-tab-panel text="sixth">sixth content</d2l-tab-panel>
+				</d2l-tabs>
+			</d2l-dropdown-tabs>
+		</d2l-dropdown>
+	</template>
+
+</dom-module>`;
+
+document.head.appendChild($_documentContainer.content);
+Polymer({
+	is: 'd2l-demo-dropdown-tabs'
+});

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,8 @@
 		<script type="module" src="../../@polymer/polymer/polymer-legacy.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/dropdown/dropdown.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/dropdown/dropdown-tabs.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
 		<script type="module" src="../../d2l-button/d2l-button-subtle.js"></script>
 		<script type="module" src="../../d2l-icons/tier1-icons.js"></script>
@@ -15,6 +17,7 @@
 		<script type="module" src="./d2l-demo-templated-tabs.js"></script>
 		<script type="module" src="./d2l-demo-tabs-wrapper.js"></script>
 		<script type="module" src="./d2l-demo-tab-panel.js"></script>
+		<script type="module" src="./d2l-demo-dropdown-tabs.js"></script>
 		<!-- FIXME(polymer-modulizer):
 		These imperative modules that innerHTML your HTML are
 		a hacky way to be sure that any mixins in included style
@@ -174,6 +177,45 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<d2l-demo-tab-panel text="Physics">Tab content for Physics</d2l-demo-tab-panel>
 						<d2l-demo-tab-panel text="Math">Tab content for Math</d2l-demo-tab-panel>
 					</d2l-demo-tabs-wrapper>
+				</template>
+			</demo-snippet>
+
+			<!--
+				This demo should be moved to the dropdown demos when ported to Lit.
+				It was added here because d2l-dropdown-tabs was ported to Lit before
+				d2l-tabs and the demo pages for d2l-dropdown-tabs use d2l-tabs.
+			-->
+			<h3>Tabs (dropdown)</h3>
+
+			<demo-snippet>
+				<template>
+					<d2l-dropdown>
+						<button class="d2l-dropdown-opener">Open it!</button>
+						<d2l-dropdown-tabs min-width="175" max-width="300">
+							<d2l-tabs>
+								<d2l-tab-panel text="first">first content</d2l-tab-panel>
+								<d2l-tab-panel text="second">
+									<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+								</d2l-tab-panel>
+								<d2l-tab-panel text="third">third content</d2l-tab-panel>
+								<d2l-tab-panel text="fourth">fourth content</d2l-tab-panel>
+								<d2l-tab-panel text="fith">fith content</d2l-tab-panel>
+							</d2l-tabs>
+						</d2l-dropdown-tabs>
+					</d2l-dropdown>
+				</template>
+			</demo-snippet>
+
+			<!--
+				This demo should be moved to the dropdown demos when ported to Lit.
+				It was added here because d2l-dropdown-tabs was ported to Lit before
+				d2l-tabs and the demo pages for d2l-dropdown-tabs use d2l-tabs.
+			-->
+			<h3>Tabs (dropdown nested menu)</h3>
+
+			<demo-snippet>
+				<template>
+					<d2l-demo-dropdown-tabs></d2l-demo-dropdown-tabs>
 				</template>
 			</demo-snippet>
 

--- a/package.json
+++ b/package.json
@@ -38,13 +38,14 @@
   },
   "main": "d2l-tabs.js",
   "dependencies": {
+    "@brightspace-ui/core": "^1.30.0",
+    "@polymer/polymer": "^3.0.0",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "fastdom": "^1.0.8",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "resize-observer-polyfill": "^1.5.0",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "@polymer/polymer": "^3.0.0"
+    "fastdom": "^1.0.8",
+    "resize-observer-polyfill": "^1.5.0"
   }
 }


### PR DESCRIPTION
# This PR shouldn't be merged until core has been version bumped for the `d2l-dropdown` components.

These demos are being added here because `d2l-tabs` has not been ported to Lit so the demos in core cannot have `d2l-tabs` as a dependency. They will be moved over to be part of the dropdown demos when `d2l-tabs` gets ported to Lit.